### PR TITLE
Patch silent initialization

### DIFF
--- a/keyboard.py
+++ b/keyboard.py
@@ -104,7 +104,7 @@ class Keyboard:
     VK_X = 0x58
     VK_Y = 0x59
     VK_Z = 0x5A
-    VK_VOLUM E_MUTE = 0xAD
+    VK_VOLUME_MUTE = 0xAD
     VK_VOLUME_DOWN = 0xAE
     VK_VOLUME_UP = 0xAF
     VK_MEDIA_NEXT_TRACK = 0xB0

--- a/sound.py
+++ b/sound.py
@@ -62,7 +62,7 @@ class Sound:
         if Sound.__current_volume == None:
             Sound.__current_volume = 0
             for i in range(0, 50):
-                Sound.volume_up()
+                Sound.volume_down()     #silent is the best
 
 
     @staticmethod


### PR DESCRIPTION
When initializing, the sound is set to 0 because a sharp increase in sound brings more inconvenience than a decrease.